### PR TITLE
fix bug in Flyday::Flight#price_range

### DIFF
--- a/lib/flight.rb
+++ b/lib/flight.rb
@@ -30,9 +30,8 @@ class Flyday
 
     def price_range
       products = @blob['fareProducts']
-      max, min = products.minmax { |l| l['currencyPrice']['totalFareCents'] }
-      min = min['currencyPrice']['totalFareCents'] / 100
-      max = max['currencyPrice']['totalFareCents'] / 100
+      # Find minimum and maximum fare in dollars, excluding $0 fares, which are unavailable fares
+      min, max = (products.map{ |l| l['currencyPrice']['totalFareCents']/100 } - [0]).minmax
 
       "#{min}-#{max}"
     end

--- a/spec/flight_spec.rb
+++ b/spec/flight_spec.rb
@@ -15,7 +15,7 @@ describe Flyday do
   describe '.inspect' do
     it 'contains data about a flight' do
       ts = '2016-07-01T05:25'
-      s = "<#Flyday::Flight MDW->ATL #{ts} seats:24, price_range:220-342>"
+      s = "<#Flyday::Flight MDW->ATL #{ts} seats:24, price_range:220-358>"
       expect(@flight.inspect).to eq(s)
     end
   end
@@ -29,7 +29,7 @@ describe Flyday do
     it 'returns when the plane lands at' do
       expect(@flight.land_at).to eq('2016-07-01T08:10')
     end
-    
+
   end
   describe '.flatten' do
     it 'returns a direct flight in an array' do


### PR DESCRIPTION
The `price_range` method isn't properly calling `minmax`, which can result in wrong data. I saw this first-hand when an "Anytime" Fare was available, but "Business Select" and "Wanna Get Away" fares were not. This change calls `minmax` on the values of `l['currencyPrice']['totalFareCents']` rather than the products array itself.

I went to update the tests, but found that VCR example was actually showing the incorrectness already:
```
          "fareProducts":[  
            {  
              "productId":"S0xORVZ8QW1lcmljYS9DaGljYWdvfDIwMTYwNzAxMDUyNSwyMDE2MDcwMTA4MTB8TURXLUFUTHxXTjMwOXxLfEFEVHw3M1c=",
              "fareType":"BusinessSelect",
              "seatsAvailable":"8",
              "unavailabilityReason":"NONE",
              "bookingCode":"K",
              "fareBasisCode":"KLNEV",
              "paxPricingType":"ADT",
              "currencyPrice":{  
                "totalFareCents":35800,
                "discountedTotalFareCents":35800,
                "accrualPoints":3839
              }
            },
            {  
              "productId":"WUxORVZ8QW1lcmljYS9DaGljYWdvfDIwMTYwNzAxMDUyNSwyMDE2MDcwMTA4MTB8TURXLUFUTHxXTjMwOXxZfEFEVHw3M1c=",
              "fareType":"Anytime",
              "seatsAvailable":"8",
              "unavailabilityReason":"NONE",
              "bookingCode":"Y",
              "fareBasisCode":"YLNEV",
              "paxPricingType":"ADT",
              "currencyPrice":{  
                "totalFareCents":34200,
                "discountedTotalFareCents":34200,
                "accrualPoints":3050
              }
            },
            {  
              "productId":"V0xOQ1BOUnxBbWVyaWNhL0NoaWNhZ298MjAxNjA3MDEwNTI1LDIwMTYwNzAxMDgxMHxNRFctQVRMfFdOMzA5fFd8QURUfDczVw==",
              "fareType":"WannaGet Away",
              "seatsAvailable":"8",
              "unavailabilityReason":"NONE",
              "bookingCode":"W",
              "fareBasisCode":"WLNCPNR",
              "paxPricingType":"ADT",
              "currencyPrice":{  
                "totalFareCents":22000,
                "discountedTotalFareCents":22000,
                "accrualPoints":1149
              }
            }
          ]
```
The maximum fare in this cassette is $358, but the spec was expecting $342.